### PR TITLE
feat: framework to add request metadata

### DIFF
--- a/packages/core/lib/busses/command.bus.spec.ts
+++ b/packages/core/lib/busses/command.bus.spec.ts
@@ -1,13 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { Test } from "@nestjs/testing";
+import { TestCommand } from "../../testing-classes/test.command";
 import { MemoryCache } from "../caches/memory.cache";
-import { Command } from "../classes/command.class";
 import { SagaManager } from "../classes/saga-manager.class";
 import { CommandHandler } from "../decorators/command-handler.decorator";
-import { RegisterType } from "../decorators/register-type.decorator";
 import { ObservableFactory } from "../factories/observable.factory";
 import { ICommandHandler } from "../interfaces/command-handler.interface";
-import { ICommand } from "../interfaces/command.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import {
   CACHE_PROVIDER,
@@ -16,13 +14,6 @@ import {
 } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
 import { CommandBus } from "./command.bus";
-
-@RegisterType()
-export class TestCommand extends Command implements ICommand {
-  public $version = 1;
-  $responseKey = "hello";
-  $routingKey = "world";
-}
 
 @CommandHandler(TestCommand)
 class TestHandler implements ICommandHandler<TestCommand> {

--- a/packages/core/lib/busses/event.bus.spec.ts
+++ b/packages/core/lib/busses/event.bus.spec.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { randomUUID } from "crypto";
+import { TestCommand } from "../../testing-classes/test.command";
 import { TestEvent } from "../../testing-classes/test.event";
 import { MemoryCache } from "../caches/memory.cache";
 import { Event } from "../classes/event.class";
@@ -25,7 +26,6 @@ import {
 import { MemoryPublisher } from "../publishers/memory.publisher";
 import { MemoryStore } from "../stores/memory.store";
 import { CommandBus } from "./command.bus";
-import { TestCommand } from "./command.bus.spec";
 import { EventBus } from "./event.bus";
 
 @EventHandler(TestEvent)

--- a/packages/core/lib/classes/aggregate-root.class.ts
+++ b/packages/core/lib/classes/aggregate-root.class.ts
@@ -85,7 +85,8 @@ export abstract class AggregateRoot<Projection = Record<string, unknown>> {
   public async commit(): Promise<void>;
   /**
    * Commit all uncommitted events to the store and link those events
-   * to the provided Command via `Command.$correlationId`
+   * to the provided Command via `Command.$correlationId`. Additionally pass
+   * on any metadata included as part of the command.
    */
   public async commit(initiatorCommand: ICommand): Promise<void>;
   public async commit(initiatorCommand?: ICommand): Promise<void> {
@@ -94,6 +95,8 @@ export abstract class AggregateRoot<Projection = Record<string, unknown>> {
       this.uncommittedEventHistory.map((event) => {
         if (!event.$correlationId)
           event.$correlationId = initiatorCommand?.$correlationId;
+        if (initiatorCommand?.$metadata)
+          event.$metadata = initiatorCommand.$metadata;
         return event;
       }),
     );

--- a/packages/core/lib/classes/event.class.ts
+++ b/packages/core/lib/classes/event.class.ts
@@ -1,5 +1,6 @@
 import { Type } from "class-transformer";
 import { EventType } from "../interfaces/event-like.interface";
+import { IRequestMetadata } from "../interfaces/request-metadata.interface";
 import { Eventable } from "./eventable.class";
 
 export abstract class Event extends Eventable {
@@ -8,8 +9,8 @@ export abstract class Event extends Eventable {
   public readonly $timestamp: Date;
   public readonly $type = EventType.EVENT;
 
-  constructor() {
-    super();
+  constructor(metadata: IRequestMetadata = {}) {
+    super(metadata);
     this.$timestamp = new Date();
   }
 }

--- a/packages/core/lib/classes/eventable.class.ts
+++ b/packages/core/lib/classes/eventable.class.ts
@@ -4,7 +4,7 @@ export abstract class Eventable {
   public readonly $name: string;
   public readonly $uuid: string;
 
-  constructor() {
+  constructor(public $metadata = {}) {
     this.$name = this.constructor.name;
     this.$uuid = randomUUID();
   }

--- a/packages/core/lib/classes/saga.class.spec.ts
+++ b/packages/core/lib/classes/saga.class.spec.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
+import { TestCommand } from "../../testing-classes/test.command";
 import { TestEvent } from "../../testing-classes/test.event";
-import { TestCommand } from "../busses/command.bus.spec";
 import { MemoryCache } from "../caches/memory.cache";
 import { SagaStep } from "../decorators/saga-step.decorator";
 import { IEvent } from "../interfaces/event.interface";

--- a/packages/core/lib/interfaces/event-like.interface.ts
+++ b/packages/core/lib/interfaces/event-like.interface.ts
@@ -1,3 +1,5 @@
+import { IRequestMetadata } from "./request-metadata.interface";
+
 export enum EventType {
   COMMAND = "COMMAND",
   EVENT = "EVENT",
@@ -5,6 +7,10 @@ export enum EventType {
 }
 
 export interface IEventLike {
+  /**
+   * Object containing metadata about the initiating request
+   */
+  $metadata?: IRequestMetadata;
   /**
    * Event name. Defaults to the name of the constructor
    */

--- a/packages/core/lib/interfaces/request-metadata.interface.ts
+++ b/packages/core/lib/interfaces/request-metadata.interface.ts
@@ -1,0 +1,5 @@
+/**
+ * Metadata about the request to be stored and propagated with the commands/queries/events.
+ * Optional to include.
+ */
+export type IRequestMetadata = Record<string, unknown>;

--- a/packages/core/testing-classes/test.command.ts
+++ b/packages/core/testing-classes/test.command.ts
@@ -1,0 +1,10 @@
+import { Command } from "../lib/classes/command.class";
+import { RegisterType } from "../lib/decorators/register-type.decorator";
+import { ICommand } from "../lib/interfaces/command.interface";
+
+@RegisterType()
+export class TestCommand extends Command implements ICommand {
+  public $version = 1;
+  $responseKey = "hello";
+  $routingKey = "world";
+}


### PR DESCRIPTION
Add ability to track request metadata as part of the event storage for better visibility and audit trail