### PR TITLE
feat: export state tracker and fix early return

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,4 +10,4 @@ yarnPath: .yarn/releases/yarn-3.2.0.cjs
 
 npmRegistries:
   //registry.npmjs.org:
-    npmAuthToken: ${NPM_TOKEN}
+    npmAuthToken: ${NPM_TOKEN-helloWorld}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -14,6 +14,7 @@ export { Event } from "./lib/classes/event.class";
 export { Query } from "./lib/classes/query.class";
 export { ResponseWrapper } from "./lib/classes/response.class";
 export { Saga } from "./lib/classes/saga.class";
+export { StateTracker } from "./lib/classes/state-tracker.class";
 // decorators
 export { Apply } from "./lib/decorators/apply.decorator";
 export { CommandHandler } from "./lib/decorators/command-handler.decorator";

--- a/packages/core/lib/classes/state-tracker.class.spec.ts
+++ b/packages/core/lib/classes/state-tracker.class.spec.ts
@@ -55,6 +55,10 @@ describe("StateTracker", () => {
     expect(Date.now()).toBeGreaterThanOrEqual(startTime + 500);
   });
 
+  it("will return immediately if the current state is correct", async () => {
+    expect(await tracker.await(TestStatuses.hello)).toEqual(TestStatuses.hello);
+  });
+
   it("will throw a timeout error if waiting too long", async () => {
     await expect(() =>
       tracker.await(TestStatuses.world),

--- a/packages/core/lib/classes/state-tracker.class.ts
+++ b/packages/core/lib/classes/state-tracker.class.ts
@@ -31,6 +31,7 @@ export class StateTracker<T> {
   }
 
   public await(desiredState: T): Promise<T> {
+    if (this._state === desiredState) return Promise.resolve(this._state);
     return new Promise((res, rej) => {
       const timeout = setTimeout(() => {
         rej(new Error("HI"));


### PR DESCRIPTION
- Add StateTracker class as an export
- Fix StateTracker.await to return early if current state equals desired state