### PR TITLE
Fix/improve command error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,13 +5,13 @@ const config = JSON.parse(fs.readFileSync(`${__dirname}/.swcrc`, "utf-8"));
 
 module.exports = {
   moduleFileExtensions: ["js", "json", "ts"],
-  // rootDir: "lib",
-  testRegex: ".*\\.spec\\.ts$",
+  rootDir: `packages${process.env.JEST_ROOT_DIR ? '/' + process.env.JEST_ROOT_DIR : ''}`,
+  testRegex: '\\.*\\.spec\\.ts$',
   transform: {
     "^.+\\.(t|j)s$": ["@swc/jest", { ...config }]
   },
   collectCoverageFrom: ["**/*.(t|j)s"],
   coverageDirectory: "../coverage",
   testEnvironment: "node",
-  setupFilesAfterEnv: ["./jest.setup.js"]
+  setupFilesAfterEnv: ["../../jest.setup.js"]
 };

--- a/packages/core/lib/exceptions/command-execution.error.ts
+++ b/packages/core/lib/exceptions/command-execution.error.ts
@@ -1,0 +1,12 @@
+import { RegisterType } from "../decorators/register-type.decorator";
+import { ICommand } from "../interfaces/command.interface";
+
+@RegisterType()
+export class CommandExecutionError extends Error {
+  constructor(public readonly command: ICommand) {
+    super(
+      `Command execution for command ${command.$name}:${command.$uuid} has failed`,
+    );
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,6 @@
     "build": "yarn prebuild && tsc",
     "prebuild": "rimraf ./dist",
     "pack": "npm pack",
-    "test": "jest --config=../../jest.config.js --roots=packages/core/lib"
+    "test": "env JEST_ROOT_DIR=core jest --config=../../jest.config.js"
   }
 }

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -44,6 +44,6 @@
   "scripts": {
     "build": "yarn prebuild && tsc",
     "prebuild": "rimraf ./dist",
-    "test": "jest --config=../../jest.config.js --roots=packages/rabbitmq/lib"
+    "test": "env JEST_ROOT_DIR=rabbitmq jest --config=../../jest.config.js"
   }
 }

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "yarn prebuild && tsc",
     "prebuild": "rimraf ./dist",
-    "test": "jest --config=../../jest.config.js --roots=packages/redis/lib"
+    "test": "env JEST_ROOT_DIR=redis jest --config=../../jest.config.js"
   },
   "dependencies": {
     "redis": "^4.2.0"

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -46,6 +46,6 @@
   "scripts": {
     "build": "yarn prebuild && tsc",
     "prebuild": "rimraf ./dist",
-    "test": "jest --config=../../jest.config.js --roots=packages/typeorm/lib"
+    "test": "env JEST_ROOT_DIR=typeorm jest --config=../../jest.config.js"
   }
 }


### PR DESCRIPTION
- Fix jest configs
- Modify `CommandBus.execute` with `throwError` option to throw actual error if possible or wrap in `CommandExecutionError` for handling elsewhere