### PR TITLE
Feat/namespace respondables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The publisher provides a structure for passing messages between nodes of a distr
 - Request/Response for Commands
 - Request/Response for Queries
 - Event processing
-- Post-processing distribution of events
+- Pre and Post processing distribution of events
 
 #### Supported
 - [x] RabbitMQ

--- a/demo-app/test/account.e2e-spec.ts
+++ b/demo-app/test/account.e2e-spec.ts
@@ -129,13 +129,13 @@ describe("Account", () => {
         .expect(201)
         .expect(({ body }) => {
           id = body.streamId;
+          wsClient.send(
+            JSON.stringify({
+              event: Subscriptions.ID,
+              data: { id },
+            }),
+          );
         });
-      wsClient.send(
-        JSON.stringify({
-          event: Subscriptions.ID,
-          data: { id },
-        }),
-      );
       await wsClient.awaitMatch(
         (event) =>
           event.$name === "AccountCreatedEvent" && event.$streamId === id,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "demo": "yarn workspace demo-app",
     "document": "typedoc",
     "lint": "eslint --fix",
-    "packages": "yarn workspaces foreach --exclude=demo-app --exclude=moirae",
+    "packages": "yarn workspaces foreach --exclude=demo-app --exclude=moirae run",
     "prepare": "husky install",
     "redis": "yarn workspace @moirae/redis",
     "rmq": "yarn workspace @moirae/rabbitmq",

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -58,6 +58,7 @@ export {
   EVENT_PUBSUB_ENGINE,
   EVENT_SOURCE,
   PUBLISHER,
+  PublisherRole,
   PUBLISHER_OPTIONS,
 } from "./lib/moirae.constants";
 // modules

--- a/packages/core/lib/busses/command.bus.ts
+++ b/packages/core/lib/busses/command.bus.ts
@@ -12,7 +12,12 @@ import { ICommandHandlerOptions } from "../interfaces/command-handler-options.in
 import { ICommand } from "../interfaces/command.interface";
 import { ExecuteOptions } from "../interfaces/execute-options.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
-import { COMMAND_METADATA, ESState, PUBLISHER } from "../moirae.constants";
+import {
+  COMMAND_METADATA,
+  ESState,
+  PUBLISHER,
+  PublisherRole,
+} from "../moirae.constants";
 
 /**
  * Provide the ability to run commands either locally or on remote systems
@@ -27,7 +32,7 @@ export class CommandBus extends BaseBus<ICommand> {
     private readonly _sagaManager: SagaManager,
   ) {
     super(explorer, COMMAND_METADATA, observableFactory, publisher);
-    this._publisher.role = "__command-bus__";
+    this._publisher.role = PublisherRole.COMMAND_BUS;
   }
 
   public async execute<TRes = CommandResponse>(

--- a/packages/core/lib/busses/query.bus.ts
+++ b/packages/core/lib/busses/query.bus.ts
@@ -4,7 +4,7 @@ import { Explorer } from "../classes/explorer.class";
 import { ObservableFactory } from "../factories/observable.factory";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { IQuery } from "../interfaces/query.interface";
-import { PUBLISHER, QUERY_METADATA } from "../moirae.constants";
+import { PUBLISHER, PublisherRole, QUERY_METADATA } from "../moirae.constants";
 
 /**
  * Provide the ability to run queries either locally or on remote systems
@@ -18,6 +18,6 @@ export class QueryBus extends BaseBus<IQuery> {
     @Inject(PUBLISHER) publisher: IPublisher,
   ) {
     super(explorer, QUERY_METADATA, observableFactory, publisher);
-    this._publisher.role = "__query-bus__";
+    this._publisher.role = PublisherRole.QUERY_BUS;
   }
 }

--- a/packages/core/lib/classes/base.bus.ts
+++ b/packages/core/lib/classes/base.bus.ts
@@ -41,6 +41,7 @@ export abstract class BaseBus<T extends Respondable>
     const { throwError = false } = options;
     const _key = randomUUID();
     event.$responseKey = _key;
+    if (!event.$executionDomain) event.$executionDomain = "default";
     await this._publisher.publish(event);
     const res = await this._publisher.awaitResponse(_key);
     if (res.payload instanceof Error && throwError) throw res.payload;

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -8,7 +8,7 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { IPublisherConfig } from "../interfaces/publisher-config.interface";
 import { Respondable } from "../interfaces/respondable.interface";
 import { EventProcessor } from "../mixins/event-processor.mixin";
-import { ESState } from "../moirae.constants";
+import { ESState, PublisherRole } from "../moirae.constants";
 import { Distributor } from "./distributor.class";
 import { ResponseWrapper } from "./response.class";
 import { StateTracker } from "./state-tracker.class";
@@ -27,7 +27,7 @@ export abstract class BasePublisher<Evt extends Respondable>
   protected _status: StateTracker<ESState>;
   protected readonly _uuid: string;
 
-  public role: string;
+  public role: PublisherRole;
 
   constructor(
     observableFactory: ObservableFactory,

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -70,7 +70,10 @@ export abstract class BasePublisher<Evt extends Respondable>
 
   protected abstract handleAcknowledge(event: Evt): Promise<void>;
   protected abstract handleBootstrap(): Promise<void>;
-  protected abstract handlePublish(eventString: string): Promise<void>;
+  protected abstract handlePublish(
+    eventString: string,
+    executionDomain: string,
+  ): Promise<void>;
   /**
    * Handle publishing the response outbound
    */
@@ -101,7 +104,7 @@ export abstract class BasePublisher<Evt extends Respondable>
   public async publish(event: Evt): Promise<void> {
     event.$routingKey = this.publisherOptions.nodeId;
     const serialized = this.serializeEvent(event);
-    await this.handlePublish(serialized);
+    await this.handlePublish(serialized, event.$executionDomain || "default");
   }
 
   protected parseResponse(responseString: string): ResponseWrapper<unknown> {

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -15,7 +15,6 @@ import { StateTracker } from "./state-tracker.class";
 
 export const EVENT_KEY = "__event_key__";
 
-// @AddMixin(EventProcessor)
 export abstract class BasePublisher<Evt extends Respondable>
   extends EventProcessor<Evt>
   implements

--- a/packages/core/lib/classes/command.class.ts
+++ b/packages/core/lib/classes/command.class.ts
@@ -3,6 +3,7 @@ import { Eventable } from "./eventable.class";
 
 export abstract class Command extends Eventable {
   public $correlationId: string;
+  public $executionDomain: "default" | string;
   public $responseKey: string;
   public $routingKey: string;
   public readonly $type = EventType.COMMAND;

--- a/packages/core/lib/classes/query.class.ts
+++ b/packages/core/lib/classes/query.class.ts
@@ -3,6 +3,7 @@ import { Eventable } from "./eventable.class";
 
 export abstract class Query extends Eventable {
   public readonly $type = EventType.QUERY;
+  public $executionDomain: "default" | string;
   public $responseKey: string;
   public $routingKey: string;
 }

--- a/packages/core/lib/interfaces/publisher-config.interface.ts
+++ b/packages/core/lib/interfaces/publisher-config.interface.ts
@@ -2,6 +2,13 @@ export type PublisherType = "memory" | "rabbitmq";
 
 export interface IPublisherConfig {
   /**
+   * In the case of a microservice system, define the domain token for this
+   * specific microservice.
+   *
+   * @default default
+   */
+  domain?: "default" | string;
+  /**
    * Globally unique ID for the system. Suggested: kubernetes pod name
    */
   nodeId: string;

--- a/packages/core/lib/interfaces/publisher.interface.ts
+++ b/packages/core/lib/interfaces/publisher.interface.ts
@@ -1,4 +1,5 @@
 import { ResponseWrapper } from "../classes/response.class";
+import { PublisherRole } from "../moirae.constants";
 import { IEventLike } from "./event-like.interface";
 
 /**
@@ -23,7 +24,7 @@ export interface IPublisher<Evt = IEventLike> {
   /**
    * Define the role of the publisher within the application. Set via the using class
    */
-  role: string;
+  role: PublisherRole;
   /**
    * Subscribe to the bus. Should only be called ONCE by the relevant
    * bus as will trigger acknowledgements.

--- a/packages/core/lib/interfaces/respondable.interface.ts
+++ b/packages/core/lib/interfaces/respondable.interface.ts
@@ -7,6 +7,11 @@ export interface Respondable extends IEventLike {
    */
   $disableResponse?: boolean;
   /**
+   * Property set on any respondable to define the executing system
+   * for working with non-monolithic applications
+   */
+  $executionDomain?: "default" | string;
+  /**
    * Unique key to associate a response to a request
    */
   $responseKey?: string;

--- a/packages/core/lib/moirae.constants.ts
+++ b/packages/core/lib/moirae.constants.ts
@@ -25,3 +25,12 @@ export enum ESState {
   ACTIVE,
   SHUTTING_DOWN,
 }
+
+/**
+ * @internal
+ */
+export enum PublisherRole {
+  COMMAND_BUS = "COMMAND_BUS",
+  EVENT_STORE = "EVENT_STORE",
+  QUERY_BUS = "QUERY_BUS",
+}

--- a/packages/core/lib/moirae.module.ts
+++ b/packages/core/lib/moirae.module.ts
@@ -45,6 +45,7 @@ export class MoiraeModule {
       },
       externalTypes = [],
       publisher = {
+        domain: "default",
         type: "memory",
       },
       sagas = [],
@@ -53,6 +54,7 @@ export class MoiraeModule {
       },
       imports,
     } = config;
+    if (!publisher.domain) publisher.domain = "default";
     externalTypes.forEach((type) => ConstructorStorage.getInstance().set(type));
 
     const providers: Provider[] = [

--- a/packages/core/lib/stores/memory.store.ts
+++ b/packages/core/lib/stores/memory.store.ts
@@ -3,7 +3,7 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { IEventSource } from "../interfaces/event-source.interface";
 import { IEvent } from "../interfaces/event.interface";
 import { IPublisherConfig } from "../interfaces/publisher-config.interface";
-import { PUBLISHER_OPTIONS } from "../moirae.constants";
+import { PublisherRole, PUBLISHER_OPTIONS } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
 
 @Injectable()
@@ -18,7 +18,7 @@ export class MemoryStore
     @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherConfig,
   ) {
     super(observableFactory, publisherOptions);
-    this.role = "__event-store__";
+    this.role = PublisherRole.EVENT_STORE;
   }
 
   public async appendToStream(eventList: IEvent[]): Promise<IEvent[]> {

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -24,11 +24,9 @@ A Moirae publisher leveraging RabbitMQ as a transport layer providing:
 In cases where events should be published externally to the application (in the case of analytics for instance), there are two ways to subscribe to the event stream.
 
 ### Pre-processing
-To subscribe pre-processing, meaning before the core application has processed and stored the event, first create a queue for the service and bind the queue to the event store exchange with either the `domain` field specified in the configuration or with `#` to subscribe to all by default.
+To subscribe pre-processing, meaning before the core application has processed but after storing the event, first create a queue for the service and bind the queue to the event store exchange.
 
-Related: [Topic Exchange](https://www.rabbitmq.com/tutorials/tutorial-five-python.html)
+Related: [Fanout Exchange](https://www.rabbitmq.com/tutorials/tutorial-three-python.html)
 
 ### Post-processing
 To subscribe post-processing within the core application, simply create a queue and bind it to the pubsub exchange. 
-
-Related: [Fanout Exchange](https://www.rabbitmq.com/tutorials/tutorial-three-python.html)

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -19,3 +19,16 @@ A Moirae publisher leveraging RabbitMQ as a transport layer providing:
 
 **`onApplicationShutdown`**
 - Tear down connection to RabbitMQ
+
+## External Systems
+In cases where events should be published externally to the application (in the case of analytics for instance), there are two ways to subscribe to the event stream.
+
+### Pre-processing
+To subscribe pre-processing, meaning before the core application has processed and stored the event, first create a queue for the service and bind the queue to the event store exchange with either the `domain` field specified in the configuration or with `#` to subscribe to all by default.
+
+Related: [Topic Exchange](https://www.rabbitmq.com/tutorials/tutorial-five-python.html)
+
+### Post-processing
+To subscribe post-processing within the core application, simply create a queue and bind it to the pubsub exchange. 
+
+Related: [Fanout Exchange](https://www.rabbitmq.com/tutorials/tutorial-three-python.html)

--- a/packages/rabbitmq/lib/publishers/rabbitmq.publisher.ts
+++ b/packages/rabbitmq/lib/publishers/rabbitmq.publisher.ts
@@ -5,6 +5,7 @@ import {
   IEventLike,
   IPublisher,
   ObservableFactory,
+  PublisherRole,
   PUBLISHER_OPTIONS,
 } from "@moirae/core";
 import { Inject, Injectable, Scope } from "@nestjs/common";
@@ -78,7 +79,10 @@ export class RabbitMQPublisher
     this._workChannel =
       await this.rabbitMQConnection.connection.createChannel();
     await this._workChannel.prefetch(1);
-    await this._workChannel.assertExchange(this._WORK_EXCHANGE, "topic");
+    await this._workChannel.assertExchange(
+      this._WORK_EXCHANGE,
+      this.role === PublisherRole.EVENT_STORE ? "fanout" : "topic",
+    );
     await this._workChannel.assertQueue(this._WORK_QUEUE);
     await this._workChannel.bindQueue(
       this._WORK_QUEUE,

--- a/packages/rabbitmq/lib/publishers/rabbitmq.publisher.ts
+++ b/packages/rabbitmq/lib/publishers/rabbitmq.publisher.ts
@@ -18,12 +18,13 @@ export class RabbitMQPublisher
   implements IPublisher
 {
   private _activeInbound: AsyncMap<Message>;
-  private _EXCHANGE: string;
   private _responseChannel: Channel;
   private _responseConsumer: string;
+  private _RESPONSE_EXCHANGE: string;
   private _RESPONSE_QUEUE: string;
   private _workChannel: Channel;
   private _workConsumer: string;
+  private _WORK_EXCHANGE: string;
   private _WORK_QUEUE: string;
 
   protected publisherOptions: IRabbitMQConfig;
@@ -45,19 +46,23 @@ export class RabbitMQPublisher
   }
 
   protected async handleBootstrap(): Promise<void> {
-    this._EXCHANGE = `${this.publisherOptions.namespaceRoot}-responseExchange-${this.role}`;
+    this._RESPONSE_EXCHANGE = `${this.publisherOptions.namespaceRoot}-responseExchange-${this.role}`;
     this._RESPONSE_QUEUE = `${this.publisherOptions.namespaceRoot}-responses-${this.role}-${this.publisherOptions.nodeId}`;
-    this._WORK_QUEUE = `${this.publisherOptions.namespaceRoot}-work-${this.role}`;
+    this._WORK_EXCHANGE = `${this.publisherOptions.namespaceRoot}-workExchange-${this.role}`;
+    this._WORK_QUEUE = `${this.publisherOptions.namespaceRoot}-work-${this.role}-${this.publisherOptions.domain}`;
 
     this._responseChannel =
       await this.rabbitMQConnection.connection.createChannel();
-    await this._responseChannel.assertExchange(this._EXCHANGE, "direct");
+    await this._responseChannel.assertExchange(
+      this._RESPONSE_EXCHANGE,
+      "direct",
+    );
     await this._responseChannel.assertQueue(this._RESPONSE_QUEUE, {
       exclusive: true,
     });
     await this._responseChannel.bindQueue(
       this._RESPONSE_QUEUE,
-      this._EXCHANGE,
+      this._RESPONSE_EXCHANGE,
       this.publisherOptions.nodeId,
     );
 
@@ -73,7 +78,14 @@ export class RabbitMQPublisher
     this._workChannel =
       await this.rabbitMQConnection.connection.createChannel();
     await this._workChannel.prefetch(1);
+    await this._workChannel.assertExchange(this._WORK_EXCHANGE, "topic");
     await this._workChannel.assertQueue(this._WORK_QUEUE);
+    await this._workChannel.bindQueue(
+      this._WORK_QUEUE,
+      this._WORK_EXCHANGE,
+      this.publisherOptions.domain,
+    );
+
     ({ consumerTag: this._workConsumer } = await this._workChannel.consume(
       this._WORK_QUEUE,
       (msg) => {
@@ -91,8 +103,15 @@ export class RabbitMQPublisher
     ));
   }
 
-  protected async handlePublish(eventString: string): Promise<void> {
-    this._workChannel.sendToQueue(this._WORK_QUEUE, Buffer.from(eventString));
+  protected async handlePublish(
+    eventString: string,
+    executionDomain: string,
+  ): Promise<void> {
+    this._workChannel.publish(
+      this._WORK_EXCHANGE,
+      executionDomain,
+      Buffer.from(eventString),
+    );
   }
 
   protected async handleResponse(
@@ -100,7 +119,7 @@ export class RabbitMQPublisher
     responseJSON: string,
   ): Promise<void> {
     this._responseChannel.publish(
-      this._EXCHANGE,
+      this._RESPONSE_EXCHANGE,
       routingKey,
       Buffer.from(responseJSON),
     );
@@ -112,7 +131,7 @@ export class RabbitMQPublisher
 
     await this._responseChannel.unbindQueue(
       this._RESPONSE_QUEUE,
-      this._EXCHANGE,
+      this._RESPONSE_EXCHANGE,
       this.publisherOptions.nodeId,
     );
     await this._responseChannel.cancel(this._responseConsumer);

--- a/packages/typeorm/lib/stores/typeorm.store.ts
+++ b/packages/typeorm/lib/stores/typeorm.store.ts
@@ -4,6 +4,7 @@ import {
   IEventSource,
   IPublisher,
   PUBLISHER,
+  PublisherRole,
 } from "@moirae/core";
 import { Inject, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -22,7 +23,7 @@ export class TypeORMStore
     private readonly repository: Repository<EventStore>,
   ) {
     super();
-    this.publisher.role = "__event-store__";
+    this.publisher.role = PublisherRole.EVENT_STORE;
   }
 
   public async appendToStream(


### PR DESCRIPTION
To allow for microservice and no-Moirae based systems to interact:

- Commands and Queries should have an executionDomain to define what system they may run on
- For RabbitMQPublisher
  - All Commands and Queries should be published to a `topic` exchange
  - All Events should be published to a `fanout` exchange
  - Add assertions for creating aforementioned exchanges
  - Update documentation for non-Moirae systems to subscribe pre and post processing