### PR TITLE
feat: add mixin functionality

### DIFF
--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -42,7 +42,7 @@
     "typeorm": "^0.2"
   },
   "devDependencies": {
-    "@faker-js/faker": "^6.3.1",
+    "@faker-js/faker": "^7.4.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^8.0.0",
     "@nestjs/testing": "^8.4.7",

--- a/demo-app/src/account/handlers/create-order.handler.spec.ts
+++ b/demo-app/src/account/handlers/create-order.handler.spec.ts
@@ -1,4 +1,4 @@
-import faker from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 import { AggregateFactory, mockAggregateFactory } from "@moirae/core";
 import { Test } from "@nestjs/testing";
 import { InventoryAggregate } from "../../inventory/aggregates/inventory.aggregate";

--- a/demo-app/src/account/handlers/funds-deposited.handler.spec.ts
+++ b/demo-app/src/account/handlers/funds-deposited.handler.spec.ts
@@ -1,4 +1,4 @@
-import faker from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 import { AggregateFactory, mockAggregateFactory } from "@moirae/core";
 import { Test } from "@nestjs/testing";
 import { AccountService } from "../account.service";

--- a/demo-app/src/app.module.ts
+++ b/demo-app/src/app.module.ts
@@ -26,6 +26,7 @@ import { AppService } from "./app.service";
 import { ProcessOrderSaga } from "./common/sagas/process-order.saga";
 import { InventoryModule } from "./inventory/inventory.module";
 import { MoiraeWsGateway } from "./moirae-ws.gateway";
+import { UserManagementModule } from "./user-management/user-management.module";
 
 const moiraeConfigGenerator = (): IMoiraeConfig<
   ICacheConfig,
@@ -116,6 +117,7 @@ const moiraeConfigGenerator = (): IMoiraeConfig<
       type: "sqlite",
       synchronize: true,
     }),
+    UserManagementModule,
   ],
   controllers: [AppController],
   providers: [AppService, MoiraeWsGateway],

--- a/demo-app/src/common/interfaces/dynamic-aggregate.interface.ts
+++ b/demo-app/src/common/interfaces/dynamic-aggregate.interface.ts
@@ -1,0 +1,5 @@
+import { IEvent } from "@moirae/core";
+
+export interface IDynamicAggregate {
+  postAggregateShift(event: IEvent): void;
+}

--- a/demo-app/src/user-management/aggregates/customer.aggregate.spec.ts
+++ b/demo-app/src/user-management/aggregates/customer.aggregate.spec.ts
@@ -1,0 +1,39 @@
+import { faker } from "@faker-js/faker";
+import { CompanyNameUpdatedEvent } from "../events/company-name-updated.event";
+import { UserAssignedAsCustomerEvent } from "../events/user-assigned-as-customer.event";
+import { UserCreatedEvent } from "../events/user-created.event";
+import { CustomerAggregate } from "./customer.aggregate";
+import { UserAggregate } from "./user.aggregate";
+
+describe("CustomerAggregate", () => {
+  let customer: CustomerAggregate;
+
+  beforeEach(() => {
+    customer = new UserAggregate(faker.datatype.uuid()) as CustomerAggregate;
+    customer.apply(
+      new UserCreatedEvent(customer.id, {
+        email: faker.datatype.uuid(),
+      }),
+    );
+    customer.apply(
+      new UserAssignedAsCustomerEvent(customer.id, {
+        customerId: faker.datatype.uuid(),
+      }),
+    );
+  });
+
+  describe("CompanyNameUpdatedEvent", () => {
+    let event: CompanyNameUpdatedEvent;
+
+    beforeEach(() => {
+      event = new CompanyNameUpdatedEvent(customer.id, {
+        companyName: faker.company.name(),
+      });
+      customer.apply(event);
+    });
+
+    it("will apply the event", () => {
+      expect(customer.companyName).toEqual(event.$data.companyName);
+    });
+  });
+});

--- a/demo-app/src/user-management/aggregates/customer.aggregate.ts
+++ b/demo-app/src/user-management/aggregates/customer.aggregate.ts
@@ -1,0 +1,31 @@
+import { Apply } from "@moirae/core";
+import { ClassConstructor } from "class-transformer";
+import { IDynamicAggregate } from "../../common/interfaces/dynamic-aggregate.interface";
+import { CompanyNameUpdatedEvent } from "../events/company-name-updated.event";
+import { UserAssignedAsCustomerEvent } from "../events/user-assigned-as-customer.event";
+import { ICustomer } from "../interfaces/customer.interface";
+import { UserAggregate } from "./user.aggregate";
+
+export type CustomerAggregate = UserAggregate & IDynamicAggregate & ICustomer;
+
+export function DynamicCustomerAggregate<
+  T extends ClassConstructor<UserAggregate>,
+>(Base: T): ClassConstructor<CustomerAggregate> {
+  class _customerAggregate
+    extends Base
+    implements ICustomer, IDynamicAggregate
+  {
+    public companyName: string;
+    public customerId: string;
+
+    postAggregateShift(event: UserAssignedAsCustomerEvent): void {
+      this.customerId = event.$data.customerId;
+    }
+
+    @Apply(CompanyNameUpdatedEvent)
+    handleCompanyNameUpdated(event: CompanyNameUpdatedEvent): void {
+      this.companyName = event.$data.companyName;
+    }
+  }
+  return _customerAggregate;
+}

--- a/demo-app/src/user-management/aggregates/user.aggregate.spec.ts
+++ b/demo-app/src/user-management/aggregates/user.aggregate.spec.ts
@@ -1,0 +1,46 @@
+import { faker } from "@faker-js/faker";
+import { UserAssignedAsCustomerEvent } from "../events/user-assigned-as-customer.event";
+import { UserCreatedEvent } from "../events/user-created.event";
+import { UserType } from "../user-management.constants";
+import { UserAggregate } from "./user.aggregate";
+
+describe("UserAggregate", () => {
+  let user: UserAggregate;
+
+  beforeEach(() => {
+    user = new UserAggregate(faker.datatype.uuid());
+  });
+
+  describe("UserCreatedEvent", () => {
+    let event: UserCreatedEvent;
+
+    beforeEach(() => {
+      event = new UserCreatedEvent(user.id, { email: faker.internet.email() });
+      user.apply(event);
+    });
+
+    it("will apply the event", () => {
+      expect(user.email).toEqual(event.$data.email);
+    });
+  });
+
+  describe("UserAssignedAsCustomerEvent", () => {
+    let event: UserAssignedAsCustomerEvent;
+
+    beforeEach(() => {
+      user.apply(
+        new UserCreatedEvent(user.id, { email: faker.internet.email() }),
+      );
+      event = new UserAssignedAsCustomerEvent(user.id, {
+        customerId: faker.datatype.uuid(),
+      });
+      user.apply(event);
+    });
+
+    it("will change the UserType to Customer", () => {
+      expect(user.email).toBeDefined();
+      expect(user.userType).toEqual(UserType.CUSTOMER);
+      expect(user["customerId"]).toEqual(event.$data.customerId);
+    });
+  });
+});

--- a/demo-app/src/user-management/aggregates/user.aggregate.ts
+++ b/demo-app/src/user-management/aggregates/user.aggregate.ts
@@ -1,0 +1,51 @@
+import { AggregateRoot, Apply, applyMixins, IEvent } from "@moirae/core";
+import { IDynamicAggregate } from "../../common/interfaces/dynamic-aggregate.interface";
+import { UserAssignedAsCustomerEvent } from "../events/user-assigned-as-customer.event";
+import { UserCreatedEvent } from "../events/user-created.event";
+import { IUser } from "../interfaces/user.interface";
+import { UserType } from "../user-management.constants";
+import { DynamicCustomerAggregate } from "./customer.aggregate";
+
+/**
+ * A demonstration implementation of dynamic aggregates via TS mixins. Here the
+ * aggregate root for all User Accounts which can then be extended with specific behavior
+ * as defined by other aggregates, specifically the `CustomerAggregate`.
+ */
+export class UserAggregate
+  extends AggregateRoot
+  implements IUser, IDynamicAggregate
+{
+  public email: string;
+  public userType: UserType;
+
+  public get id() {
+    return this.streamId;
+  }
+
+  @Apply(UserCreatedEvent)
+  handleUserCreated(event: UserCreatedEvent): void {
+    this.email = event.$data.email;
+    this.userType = UserType.UNASSIGNED;
+  }
+
+  /**
+   * Change the userType to customer and use TS mixin functionality to alter the prototype
+   * to be a CustomerAggregate rather than a UserAggregate. This requires using the
+   * `IDynamicAggregate.postAggregateShift` method in order to handle any changes required
+   * by the new prototype to finish the conversion.
+   */
+  @Apply(UserAssignedAsCustomerEvent)
+  handleUserAssignedAsCustomer(event: UserAssignedAsCustomerEvent): void {
+    this.userType = UserType.CUSTOMER;
+    applyMixins(this, DynamicCustomerAggregate(UserAggregate));
+    this.postAggregateShift(event);
+  }
+
+  /**
+   * Stub method as a placeholder (a parallel to an abstract method) for handling
+   * aggregate conversions elsewhere.
+   */
+  postAggregateShift(event: IEvent): void {
+    // stub
+  }
+}

--- a/demo-app/src/user-management/events/company-name-updated.event.ts
+++ b/demo-app/src/user-management/events/company-name-updated.event.ts
@@ -1,0 +1,14 @@
+import { Event, IEvent, RegisterType } from "@moirae/core";
+import { ICustomer } from "../interfaces/customer.interface";
+
+@RegisterType()
+export class CompanyNameUpdatedEvent extends Event implements IEvent {
+  public readonly $version = 1;
+
+  constructor(
+    public readonly $streamId: string,
+    public readonly $data: Pick<ICustomer, "companyName">,
+  ) {
+    super();
+  }
+}

--- a/demo-app/src/user-management/events/user-assigned-as-customer.event.ts
+++ b/demo-app/src/user-management/events/user-assigned-as-customer.event.ts
@@ -1,0 +1,14 @@
+import { Event, IEvent, RegisterType } from "@moirae/core";
+import { ICustomer } from "../interfaces/customer.interface";
+
+@RegisterType()
+export class UserAssignedAsCustomerEvent extends Event implements IEvent {
+  public readonly $version = 1;
+
+  constructor(
+    public readonly $streamId: string,
+    public readonly $data: Pick<ICustomer, "customerId">,
+  ) {
+    super();
+  }
+}

--- a/demo-app/src/user-management/events/user-created.event.ts
+++ b/demo-app/src/user-management/events/user-created.event.ts
@@ -1,0 +1,14 @@
+import { Event, IEvent, RegisterType } from "@moirae/core";
+import { IUser } from "../interfaces/user.interface";
+
+@RegisterType()
+export class UserCreatedEvent extends Event implements IEvent {
+  public readonly $version = 1;
+
+  constructor(
+    public readonly $streamId: string,
+    public readonly $data: Pick<IUser, "email">,
+  ) {
+    super();
+  }
+}

--- a/demo-app/src/user-management/interfaces/customer.interface.ts
+++ b/demo-app/src/user-management/interfaces/customer.interface.ts
@@ -1,0 +1,6 @@
+import { IUser } from "./user.interface";
+
+export interface ICustomer extends IUser {
+  companyName: string;
+  customerId: string;
+}

--- a/demo-app/src/user-management/interfaces/user.interface.ts
+++ b/demo-app/src/user-management/interfaces/user.interface.ts
@@ -1,0 +1,7 @@
+import { UserType } from "../user-management.constants";
+
+export interface IUser {
+  id: string;
+  email: string;
+  userType: UserType;
+}

--- a/demo-app/src/user-management/user-management.constants.ts
+++ b/demo-app/src/user-management/user-management.constants.ts
@@ -1,0 +1,5 @@
+export enum UserType {
+  CUSTOMER = "CUSTOMER",
+  MANAGER = "MANAGER",
+  UNASSIGNED = "UNASSIGNED",
+}

--- a/demo-app/src/user-management/user-management.module.ts
+++ b/demo-app/src/user-management/user-management.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class UserManagementModule {}

--- a/demo-app/test/inventory.e2e-spec.ts
+++ b/demo-app/test/inventory.e2e-spec.ts
@@ -1,4 +1,4 @@
-import faker from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { WsAdapter } from "@nestjs/platform-ws";
 import { Test, TestingModule } from "@nestjs/testing";

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -21,7 +21,7 @@ export { StateTracker } from "./lib/classes/state-tracker.class";
 export { Apply } from "./lib/decorators/apply.decorator";
 export { CommandHandler } from "./lib/decorators/command-handler.decorator";
 export { EventHandler } from "./lib/decorators/event-handler.decorator";
-export { AddMixin } from "./lib/decorators/mixin.decorator";
+export { AddMixin, applyMixins } from "./lib/decorators/mixin.decorator";
 export { Projection } from "./lib/decorators/projection.decorator";
 export { QueryHandler } from "./lib/decorators/query-handler.decorator";
 export { RegisterType } from "./lib/decorators/register-type.decorator";

--- a/packages/core/lib/classes/aggregate-root.class.ts
+++ b/packages/core/lib/classes/aggregate-root.class.ts
@@ -62,7 +62,8 @@ export abstract class AggregateRoot<Projection = Record<string, unknown>> {
   public apply(event: IEvent): void;
   /**
    * Apply an event to the aggregate from the database. Generally not meant to be called
-   * outside aggregate population.
+   * outside aggregate population. Will NOT call AggregateRoot.postApply if `fromHistory`
+   * is true.
    */
   public apply(event: IEvent, fromHistory: boolean): void;
   public apply(event: IEvent, fromHistory = false): void {

--- a/packages/core/lib/classes/aggregate-root.class.ts
+++ b/packages/core/lib/classes/aggregate-root.class.ts
@@ -62,8 +62,7 @@ export abstract class AggregateRoot<Projection = Record<string, unknown>> {
   public apply(event: IEvent): void;
   /**
    * Apply an event to the aggregate from the database. Generally not meant to be called
-   * outside aggregate population. Will NOT call AggregateRoot.postApply if `fromHistory`
-   * is true.
+   * outside aggregate population.
    */
   public apply(event: IEvent, fromHistory: boolean): void;
   public apply(event: IEvent, fromHistory = false): void {

--- a/packages/core/lib/decorators/mixin.decorator.ts
+++ b/packages/core/lib/decorators/mixin.decorator.ts
@@ -1,13 +1,47 @@
 import { ClassConstructor } from "class-transformer";
 
+/**
+ * Apply mixin classes to the target in order they are passed. Mixin properties will
+ * override the existing methods in the target class, including any metadata that may be
+ * present in either the target or the mixin class.
+ */
+export const applyMixins = (
+  target: any,
+  ...mixins: ClassConstructor<unknown>[]
+) => {
+  mixins.forEach((baseCtor) => {
+    Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {
+      Object.defineProperty(
+        target,
+        name,
+        Object.getOwnPropertyDescriptor(baseCtor.prototype, name) ||
+          Object.create(null),
+      );
+
+      const metadataMap = new Map<string, string>(
+        Reflect.getMetadataKeys(target).map((key) => [
+          key,
+          Reflect.getMetadata(key, target),
+        ]),
+      );
+
+      Reflect.getMetadataKeys(baseCtor.prototype)
+        .filter((key) => !metadataMap.has(key))
+        .forEach((key) =>
+          metadataMap.set(key, Reflect.getMetadata(key, baseCtor.prototype)),
+        );
+
+      for (const [key, value] of metadataMap.entries()) {
+        Reflect.defineMetadata(key, value, target);
+      }
+    });
+  });
+};
+
+/**
+ * Decorator wrapper around the applyMixins function
+ */
 export const AddMixin =
   (...mixins: ClassConstructor<unknown>[]) =>
-  (target: any) => {
-    mixins.forEach((mixin) => {
-      Object.getOwnPropertyNames(mixin.prototype).forEach((name) => {
-        if (name !== "constructor") {
-          target.prototype[name] = mixin.prototype[name];
-        }
-      });
-    });
-  };
+  (target: any) =>
+    applyMixins(target, ...mixins);

--- a/packages/core/testing-classes/make-dynamic.event.ts
+++ b/packages/core/testing-classes/make-dynamic.event.ts
@@ -1,0 +1,10 @@
+import { Event } from "../lib/classes/event.class";
+import { RegisterType } from "../lib/decorators/register-type.decorator";
+import { IEvent } from "../lib/interfaces/event.interface";
+
+@RegisterType()
+export class MakeDynamicEvent extends Event implements IEvent {
+  public $streamId = "12345";
+  public readonly $version: number = 1;
+  public readonly $data = {};
+}

--- a/packages/core/testing-classes/test.aggregate.ts
+++ b/packages/core/testing-classes/test.aggregate.ts
@@ -1,9 +1,25 @@
+import { ClassConstructor } from "class-transformer";
 import { AggregateRoot } from "../lib/classes/aggregate-root.class";
 import { Apply } from "../lib/decorators/apply.decorator";
+import { applyMixins } from "../lib/decorators/mixin.decorator";
 import { Rollback } from "../lib/decorators/rollback.decorator";
+import { MakeDynamicEvent } from "./make-dynamic.event";
 import { OtherTestEvent } from "./other-test.event";
 import { RollbackOtherTestEvent } from "./rollback-other-test.event";
 import { ITestEntity, TestEvent } from "./test.event";
+import { ThirdTestEvent } from "./third-test.event";
+
+function DynamicMixinFactory<T extends ClassConstructor<TestAggregate>>(
+  base: T,
+) {
+  class DynamicMixin extends base {
+    @Apply(ThirdTestEvent)
+    handleThirdTest(event: ThirdTestEvent): void {
+      this.foo = event.$data.foo;
+    }
+  }
+  return DynamicMixin;
+}
 
 export class TestAggregate
   extends AggregateRoot<ITestEntity>
@@ -34,5 +50,10 @@ export class TestAggregate
   @Apply(RollbackOtherTestEvent)
   protected onRollbackOtherTestEvent(event: RollbackOtherTestEvent): void {
     this.foo = event.$data.foo;
+  }
+
+  @Apply(MakeDynamicEvent)
+  handleMakeDynamic(): void {
+    applyMixins(this, DynamicMixinFactory(TestAggregate));
   }
 }

--- a/packages/core/testing-classes/third-test.event.ts
+++ b/packages/core/testing-classes/third-test.event.ts
@@ -1,0 +1,11 @@
+import { Event } from "../lib/classes/event.class";
+import { RegisterType } from "../lib/decorators/register-type.decorator";
+import { IEvent } from "../lib/interfaces/event.interface";
+import { ITestEntity } from "./test.event";
+
+@RegisterType()
+export class ThirdTestEvent extends Event implements IEvent<ITestEntity> {
+  public $streamId = "12345";
+  public readonly $version: number = 1;
+  public readonly $data: ITestEntity = { foo: "bill" };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,6 +510,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@faker-js/faker@npm:7.4.0"
+  checksum: 1acebb84bfb142c08e6ba2942910d16bd92ea147fa585fa2fa9ce9983f7a8c7c016002beb7fc20ef6f7aef6c4ae9cb3fa680b275823402e34802b8489d2b980d
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -3443,7 +3450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "demo-app@workspace:demo-app"
   dependencies:
-    "@faker-js/faker": ^6.3.1
+    "@faker-js/faker": ^7.4.0
     "@moirae/core": "workspace:^"
     "@moirae/node-plugin": "workspace:^"
     "@moirae/rabbitmq": "workspace:^"


### PR DESCRIPTION
Improve and implement mixin functionality to support multiple inheritance while including decorator metadata, specifically to support the notion of a dynamic aggregate root. Example: changing a user from a `member` type to an `administrator` type. Events should behave and be handled differently in each case.