### PR TITLE
bug: allow undefined or null query responses

### DIFF
--- a/packages/core/lib/busses/query.bus.spec.ts
+++ b/packages/core/lib/busses/query.bus.spec.ts
@@ -67,14 +67,16 @@ describe("QueryBus", () => {
 
   describe("executeLocal", () => {
     it("will execute the handler", async () => {
-      expect(await bus["executeLocal"](new TestQuery())).toStrictEqual(
+      expect(await bus["executeLocal"](new TestQuery(), {})).toStrictEqual(
         new QueryResponse(),
       );
     });
 
     it("will catch, log, and return an error in execution", async () => {
       jest.spyOn(handler, "execute").mockRejectedValue(new Error());
-      expect(await bus["executeLocal"](new TestQuery())).toBeInstanceOf(Error);
+      expect(await bus["executeLocal"](new TestQuery(), {})).toBeInstanceOf(
+        Error,
+      );
     });
   });
 
@@ -87,6 +89,24 @@ describe("QueryBus", () => {
 
       query.$responseKey = expect.any(String);
       expect(publishSpy).toHaveBeenCalledWith(query);
+    });
+
+    it("will handle the case of an undefined response", async () => {
+      jest.spyOn(handler, "execute").mockResolvedValue(undefined);
+      const query = new TestQuery();
+
+      expect(await bus.execute(query)).toStrictEqual(undefined);
+
+      query.$responseKey = expect.any(String);
+    });
+
+    it("will handle the case of a null response", async () => {
+      jest.spyOn(handler, "execute").mockResolvedValue(null);
+      const query = new TestQuery();
+
+      expect(await bus.execute(query)).toStrictEqual(null);
+
+      query.$responseKey = expect.any(String);
     });
   });
 });

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -118,12 +118,7 @@ export abstract class BasePublisher<Evt extends Respondable>
   public subscribe(handlerFn: (event: Evt) => Promise<any> | any): string {
     return this._distributor.subscribe(async (evt: Evt) => {
       const res = await handlerFn(evt);
-      if (
-        !!res &&
-        !evt.$disableResponse &&
-        !!evt.$responseKey &&
-        !!evt.$routingKey
-      ) {
+      if (!evt.$disableResponse && !!evt.$responseKey && !!evt.$routingKey) {
         const response = new ResponseWrapper(
           res,
           evt.$responseKey,

--- a/packages/core/lib/classes/response.class.spec.ts
+++ b/packages/core/lib/classes/response.class.spec.ts
@@ -23,7 +23,7 @@ function jsonify<T = unknown>(payload: T): T {
 }
 
 describe("ResponseWrapper", () => {
-  const primitives = [23, false, "hello"];
+  const primitives = [23, false, "hello", undefined, null];
 
   describe("toPlain", () => {
     it.each(primitives)(

--- a/packages/core/lib/factories/observable.factory.ts
+++ b/packages/core/lib/factories/observable.factory.ts
@@ -14,6 +14,7 @@ export class ObservableFactory {
 
   constructor() {
     this._ee = new EventEmitter();
+    this._ee.setMaxListeners(1000);
   }
 
   public get emitter(): EventEmitter {


### PR DESCRIPTION
Fix issue where a query response of `null` or `undefined` would not resolve the promise and return to the initiating system.