### PR TITLE
Feat/local vs distributed execution

### DIFF
--- a/packages/core/lib/busses/command.bus.spec.ts
+++ b/packages/core/lib/busses/command.bus.spec.ts
@@ -111,9 +111,22 @@ describe("CommandBus", () => {
   });
 
   describe("execute", () => {
-    it("will call executeLocal on command and return a response", async () => {
+    it("will call executeLocal on a local command and return a response", async () => {
+      const command = new TestCommand();
+      command.$executionDomain = publisher.domain;
+
+      const localSpy = jest.spyOn(bus, "executeLocal" as never);
+      const publishSpy = jest.spyOn(publisher, "publish");
+
+      expect(await bus.execute(command)).toBeInstanceOf(CommandResponse);
+      expect(localSpy).toHaveBeenCalledWith(command);
+      expect(publishSpy).not.toHaveBeenCalled();
+    });
+
+    it("will call IPublisher.publish for commands in a different domain", async () => {
       const publishSpy = jest.spyOn(publisher, "publish");
       const command = new TestCommand();
+      command.$executionDomain = "hello world";
 
       expect(await bus.execute(command)).toBeInstanceOf(CommandResponse);
 

--- a/packages/core/lib/busses/command.bus.ts
+++ b/packages/core/lib/busses/command.bus.ts
@@ -41,7 +41,12 @@ export class CommandBus extends BaseBus<ICommand> {
   ): Promise<TRes> {
     if (!command.$correlationId) command.$correlationId = randomUUID();
     if (!command.STREAM_ID) command.STREAM_ID = randomUUID();
-    await this._publisher.publish(command);
+    if (!command.$executionDomain) command.$executionDomain = "default";
+    if (command.$executionDomain === this._publisher.domain) {
+      await this.executeLocal(command);
+    } else {
+      await this._publisher.publish(command);
+    }
     return CommandResponse.fromCommand(command) as unknown as TRes;
   }
 

--- a/packages/core/lib/busses/query.bus.spec.ts
+++ b/packages/core/lib/busses/query.bus.spec.ts
@@ -82,13 +82,13 @@ describe("QueryBus", () => {
 
   describe("execute", () => {
     it("will call executeLocal on query and return a response", async () => {
+      const localSpy = jest.spyOn(bus, "executeLocal" as never);
       const publishSpy = jest.spyOn(publisher, "publish");
       const query = new TestQuery();
 
       expect(await bus.execute(query)).toStrictEqual(new QueryResponse());
-
-      query.$responseKey = expect.any(String);
-      expect(publishSpy).toHaveBeenCalledWith(query);
+      expect(localSpy).toHaveBeenCalledWith(query, {});
+      expect(publishSpy).not.toHaveBeenCalled();
     });
 
     it("will handle the case of an undefined response", async () => {
@@ -107,6 +107,17 @@ describe("QueryBus", () => {
       expect(await bus.execute(query)).toStrictEqual(null);
 
       query.$responseKey = expect.any(String);
+    });
+
+    it("will call IPublisher.publish for queries in a separate domain", async () => {
+      const publishSpy = jest.spyOn(publisher, "publish");
+      const query = new TestQuery();
+      query.$executionDomain = "hello world";
+
+      expect(await bus.execute(query)).toStrictEqual(new QueryResponse());
+
+      query.$responseKey = expect.any(String);
+      expect(publishSpy).toHaveBeenCalledWith(query);
     });
   });
 });

--- a/packages/core/lib/busses/query.bus.ts
+++ b/packages/core/lib/busses/query.bus.ts
@@ -1,7 +1,9 @@
 import { Inject, Injectable } from "@nestjs/common";
+import { randomUUID } from "crypto";
 import { BaseBus } from "../classes/base.bus";
 import { Explorer } from "../classes/explorer.class";
 import { ObservableFactory } from "../factories/observable.factory";
+import { ExecuteOptions } from "../interfaces/execute-options.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { IQuery } from "../interfaces/query.interface";
 import { PUBLISHER, PublisherRole, QUERY_METADATA } from "../moirae.constants";
@@ -19,5 +21,35 @@ export class QueryBus extends BaseBus<IQuery> {
   ) {
     super(explorer, QUERY_METADATA, observableFactory, publisher);
     this._publisher.role = PublisherRole.QUERY_BUS;
+  }
+
+  /**
+   * Execute the provided query on a remote system
+   */
+  public async execute<TRes>(
+    query: IQuery,
+    options: ExecuteOptions = {},
+  ): Promise<TRes> {
+    const { throwError = false } = options;
+    const _key = randomUUID();
+    query.$responseKey = _key;
+
+    let res: TRes;
+
+    if (!query.$executionDomain) query.$executionDomain = "default";
+    if (query.$executionDomain === this._publisher.domain) {
+      res = (await this.executeLocal(
+        query,
+        options as Record<string, unknown>,
+      )) as TRes;
+    } else {
+      await this._publisher.publish(query);
+      const external = await this._publisher.awaitResponse(_key);
+      if (external.payload instanceof Error && throwError)
+        throw external.payload;
+      res = external.payload as TRes;
+    }
+
+    return res;
   }
 }

--- a/packages/core/lib/classes/base.bus.ts
+++ b/packages/core/lib/classes/base.bus.ts
@@ -1,9 +1,7 @@
 import { Logger, OnApplicationBootstrap } from "@nestjs/common";
 import { InstanceWrapper } from "@nestjs/core/injector/instance-wrapper";
-import { randomUUID } from "crypto";
 import { HandlerNotFoundError } from "../exceptions/handler-not-found.error";
 import { ObservableFactory } from "../factories/observable.factory";
-import { ExecuteOptions } from "../interfaces/execute-options.interface";
 import { IHandler } from "../interfaces/handler.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { Respondable } from "../interfaces/respondable.interface";
@@ -29,22 +27,6 @@ export abstract class BaseBus<T extends Respondable>
     this._status = this._observableFactory.generateStateTracker<ESState>(
       ESState.NOT_READY,
     );
-  }
-
-  /**
-   * Execute the provided command or query on a remote system
-   */
-  public async execute<TRes>(
-    event: T,
-    options: ExecuteOptions = {},
-  ): Promise<TRes> {
-    const { throwError = false } = options;
-    const _key = randomUUID();
-    event.$responseKey = _key;
-    await this._publisher.publish(event);
-    const res = await this._publisher.awaitResponse(_key);
-    if (res.payload instanceof Error && throwError) throw res.payload;
-    return res.payload as TRes;
   }
 
   /**

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -44,6 +44,10 @@ export abstract class BasePublisher<Evt extends Respondable>
     this._uuid = randomUUID();
   }
 
+  public get domain(): string {
+    return this.publisherOptions.domain || "default";
+  }
+
   protected get _key(): string {
     return `${this._uuid}:${EVENT_KEY}`;
   }

--- a/packages/core/lib/interfaces/publisher.interface.ts
+++ b/packages/core/lib/interfaces/publisher.interface.ts
@@ -7,6 +7,7 @@ import { IEventLike } from "./event-like.interface";
  * the bus. This defines the interactions the bus has with the publisher.
  */
 export interface IPublisher<Evt = IEventLike> {
+  domain: string;
   /**
    * Await the response from a remote system
    */


### PR DESCRIPTION
For the sake of performance and to remove unnecessary calls, if a `domain` has the ability to execute a given command or query, it should execute in-situ without publishing to a bus. This should also simplify the API for querying across domains and resolving data locally.