### PR TITLE
Feat/separate publisher types

### DIFF
--- a/demo-app/src/app.module.ts
+++ b/demo-app/src/app.module.ts
@@ -105,17 +105,6 @@ const moiraeConfigGenerator = (): IMoiraeConfig<
         query: rmqConfig as IPublisherConfig,
       };
       break;
-    // (config.publisher as IRabbitMQConfig) = {
-    //   ...config.publisher,
-    //   amqplib: {
-    //     hostname: process.env.RABBIT_MQ_HOST,
-    //     password: process.env.RABBIT_MQ_PASS,
-    //     port: +process.env.RABBIT_MQ_PORT,
-    //     username: process.env.RABBIT_MQ_USER,
-    //   },
-    //   namespaceRoot: "__demo-app__",
-    //   type: "rabbitmq",
-    // };
   }
 
   switch (process.env.STORE_TYPE) {

--- a/demo-app/test/setup/initServer.js
+++ b/demo-app/test/setup/initServer.js
@@ -19,20 +19,32 @@ module.exports = async () => {
             port: +process.env.RABBIT_MQ_PORT,
             username: process.env.RABBIT_MQ_USER,
           },
-        domain: 'second_app',
         namespaceRoot: "__demo-app__",
-        nodeId: 'second_app',
         type: "rabbitmq",
     }
 
-    const rmqConnection = new RabbitMQConnection(rabbitMQConfig);
+    const publisherConfig = {
+        command: rabbitMQConfig,
+        domain: 'second_app',
+        event: rabbitMQConfig,
+        nodeId: 'second_app',
+        query: rabbitMQConfig
+    }
+
+    const rmqConnection = new RabbitMQConnection(publisherConfig);
+
     const handler = {
         execute: () => 'Hello World'
     }
 
     const moirae = new MoiraePlugin(
-        {getPublisher: () => 
-            new RabbitMQPublisher(new ObservableFactory(), rabbitMQConfig, rmqConnection)
+        {
+            getCommandPublisher: () => 
+                new RabbitMQPublisher(new ObservableFactory(), publisherConfig, rmqConnection),
+            getEventPublisher: () => 
+                new RabbitMQPublisher(new ObservableFactory(), publisherConfig, rmqConnection),
+            getQueryPublisher: () => 
+                new RabbitMQPublisher(new ObservableFactory(), publisherConfig, rmqConnection)
         })
         .injectQueryHandler(handler, HelloQuery);
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -46,7 +46,10 @@ export type { IEvent } from "./lib/interfaces/event.interface";
 export type { IHandler } from "./lib/interfaces/handler.interface";
 export type { IMoiraeFilter } from "./lib/interfaces/moirae-filter.interface";
 export type { IPubSub } from "./lib/interfaces/pub-sub.interface";
-export type { IPublisherConfig } from "./lib/interfaces/publisher-config.interface";
+export type {
+  IPublisherConfig,
+  IPublisherMeta,
+} from "./lib/interfaces/publisher-config.interface";
 export type { IPublisher } from "./lib/interfaces/publisher.interface";
 export type { IQueryHandler } from "./lib/interfaces/query-handler.interface";
 export type { IQuery } from "./lib/interfaces/query.interface";
@@ -59,12 +62,14 @@ export { EventProcessor } from "./lib/mixins/event-processor.mixin";
 // constants
 export {
   CACHE_OPTIONS,
+  COMMAND_PUBLISHER,
   ESState,
+  EVENT_PUBLISHER,
   EVENT_PUBSUB_ENGINE,
   EVENT_SOURCE,
-  PUBLISHER,
   PublisherRole,
   PUBLISHER_OPTIONS,
+  QUERY_PUBLISHER,
 } from "./lib/moirae.constants";
 // modules
 export { MoiraeModule } from "./lib/moirae.module";

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -28,6 +28,8 @@ export { QueryHandler } from "./lib/decorators/query-handler.decorator";
 export { RegisterType } from "./lib/decorators/register-type.decorator";
 export { Rollback } from "./lib/decorators/rollback.decorator";
 export { SagaStep } from "./lib/decorators/saga-step.decorator";
+// errors
+export { InvalidConfigurationError } from "./lib/exceptions/invalid-configuration.error";
 // factories
 export { AggregateFactory } from "./lib/factories/aggregate.factory";
 export { ObservableFactory } from "./lib/factories/observable.factory";

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -67,7 +67,6 @@ export {
   EVENT_PUBLISHER,
   EVENT_PUBSUB_ENGINE,
   EVENT_SOURCE,
-  PublisherRole,
   PUBLISHER_OPTIONS,
   QUERY_PUBLISHER,
 } from "./lib/moirae.constants";

--- a/packages/core/lib/busses/command.bus.spec.ts
+++ b/packages/core/lib/busses/command.bus.spec.ts
@@ -15,7 +15,7 @@ import { IMoiraeFilter } from "../interfaces/moirae-filter.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import {
   CACHE_PROVIDER,
-  PUBLISHER,
+  COMMAND_PUBLISHER,
   PUBLISHER_OPTIONS,
 } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
@@ -63,7 +63,7 @@ describe("CommandBus", () => {
           useClass: MemoryCache,
         },
         {
-          provide: PUBLISHER,
+          provide: COMMAND_PUBLISHER,
           useClass: MemoryPublisher,
         },
         {

--- a/packages/core/lib/busses/command.bus.ts
+++ b/packages/core/lib/busses/command.bus.ts
@@ -15,7 +15,6 @@ import {
   COMMAND_PUBLISHER,
   ESState,
   EXCEPTION_METADATA,
-  PublisherRole,
 } from "../moirae.constants";
 
 /**
@@ -32,7 +31,7 @@ export class CommandBus extends BaseBus<ICommand> {
     private readonly _sagaManager: SagaManager,
   ) {
     super(explorer, COMMAND_METADATA, observableFactory, publisher);
-    this._publisher.role = PublisherRole.COMMAND_BUS;
+    this._publisher.role = COMMAND_PUBLISHER;
     this._errorHandlers = new Map();
   }
 

--- a/packages/core/lib/busses/command.bus.ts
+++ b/packages/core/lib/busses/command.bus.ts
@@ -12,9 +12,9 @@ import { IMoiraeFilter } from "../interfaces/moirae-filter.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import {
   COMMAND_METADATA,
+  COMMAND_PUBLISHER,
   ESState,
   EXCEPTION_METADATA,
-  PUBLISHER,
   PublisherRole,
 } from "../moirae.constants";
 
@@ -28,7 +28,7 @@ export class CommandBus extends BaseBus<ICommand> {
   constructor(
     explorer: Explorer,
     observableFactory: ObservableFactory,
-    @Inject(PUBLISHER) publisher: IPublisher,
+    @Inject(COMMAND_PUBLISHER) publisher: IPublisher,
     private readonly _sagaManager: SagaManager,
   ) {
     super(explorer, COMMAND_METADATA, observableFactory, publisher);

--- a/packages/core/lib/busses/event.bus.spec.ts
+++ b/packages/core/lib/busses/event.bus.spec.ts
@@ -19,9 +19,10 @@ import { IEventSource } from "../interfaces/event-source.interface";
 import { IEvent } from "../interfaces/event.interface";
 import {
   CACHE_PROVIDER,
+  COMMAND_PUBLISHER,
+  EVENT_PUBLISHER,
   EVENT_PUBSUB_ENGINE,
   EVENT_SOURCE,
-  PUBLISHER,
   PUBLISHER_OPTIONS,
 } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
@@ -78,7 +79,11 @@ describe("EventBus", () => {
           useClass: MemoryStore,
         },
         {
-          provide: PUBLISHER,
+          provide: EVENT_PUBLISHER,
+          useClass: MemoryPublisher,
+        },
+        {
+          provide: COMMAND_PUBLISHER,
           useClass: MemoryPublisher,
         },
         {

--- a/packages/core/lib/busses/query.bus.spec.ts
+++ b/packages/core/lib/busses/query.bus.spec.ts
@@ -7,7 +7,7 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { IQueryHandler } from "../interfaces/query-handler.interface";
 import { IQuery } from "../interfaces/query.interface";
-import { PUBLISHER, PUBLISHER_OPTIONS } from "../moirae.constants";
+import { PUBLISHER_OPTIONS, QUERY_PUBLISHER } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
 import { QueryBus } from "./query.bus";
 
@@ -42,7 +42,7 @@ describe("QueryBus", () => {
         ObservableFactory,
         QueryBus,
         {
-          provide: PUBLISHER,
+          provide: QUERY_PUBLISHER,
           useClass: MemoryPublisher,
         },
         {

--- a/packages/core/lib/busses/query.bus.ts
+++ b/packages/core/lib/busses/query.bus.ts
@@ -6,11 +6,7 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { ExecuteOptions } from "../interfaces/execute-options.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { IQuery } from "../interfaces/query.interface";
-import {
-  PublisherRole,
-  QUERY_METADATA,
-  QUERY_PUBLISHER,
-} from "../moirae.constants";
+import { QUERY_METADATA, QUERY_PUBLISHER } from "../moirae.constants";
 
 /**
  * Provide the ability to run queries either locally or on remote systems
@@ -24,7 +20,7 @@ export class QueryBus extends BaseBus<IQuery> {
     @Inject(QUERY_PUBLISHER) publisher: IPublisher,
   ) {
     super(explorer, QUERY_METADATA, observableFactory, publisher);
-    this._publisher.role = PublisherRole.QUERY_BUS;
+    this._publisher.role = QUERY_PUBLISHER;
   }
 
   /**

--- a/packages/core/lib/busses/query.bus.ts
+++ b/packages/core/lib/busses/query.bus.ts
@@ -6,7 +6,11 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { ExecuteOptions } from "../interfaces/execute-options.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { IQuery } from "../interfaces/query.interface";
-import { PUBLISHER, PublisherRole, QUERY_METADATA } from "../moirae.constants";
+import {
+  PublisherRole,
+  QUERY_METADATA,
+  QUERY_PUBLISHER,
+} from "../moirae.constants";
 
 /**
  * Provide the ability to run queries either locally or on remote systems
@@ -17,7 +21,7 @@ export class QueryBus extends BaseBus<IQuery> {
   constructor(
     explorer: Explorer,
     observableFactory: ObservableFactory,
-    @Inject(PUBLISHER) publisher: IPublisher,
+    @Inject(QUERY_PUBLISHER) publisher: IPublisher,
   ) {
     super(explorer, QUERY_METADATA, observableFactory, publisher);
     this._publisher.role = PublisherRole.QUERY_BUS;

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -5,7 +5,7 @@ import {
 import { randomUUID } from "crypto";
 import { AsyncMap } from "../classes/async-map.class";
 import { ObservableFactory } from "../factories/observable.factory";
-import { IPublisherConfig } from "../interfaces/publisher-config.interface";
+import { IPublisherMeta } from "../interfaces/publisher-config.interface";
 import { Respondable } from "../interfaces/respondable.interface";
 import { EventProcessor } from "../mixins/event-processor.mixin";
 import { ESState, PublisherRole } from "../moirae.constants";
@@ -31,7 +31,7 @@ export abstract class BasePublisher<Evt extends Respondable>
 
   constructor(
     observableFactory: ObservableFactory,
-    protected readonly publisherOptions: IPublisherConfig,
+    protected readonly publisherOptions: IPublisherMeta,
   ) {
     super();
     this._uuid = randomUUID();

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -61,6 +61,9 @@ export abstract class BasePublisher<Evt extends Respondable>
     return `${this._uuid}:${EVENT_KEY}`;
   }
 
+  /**
+   * Get specific configuration given the publisher role
+   */
   protected getRoleConfig<T extends IPublisherConfig>(): T {
     switch (this.role) {
       case COMMAND_PUBLISHER:

--- a/packages/core/lib/classes/base.publisher.ts
+++ b/packages/core/lib/classes/base.publisher.ts
@@ -5,10 +5,19 @@ import {
 import { randomUUID } from "crypto";
 import { AsyncMap } from "../classes/async-map.class";
 import { ObservableFactory } from "../factories/observable.factory";
-import { IPublisherMeta } from "../interfaces/publisher-config.interface";
+import {
+  IPublisherConfig,
+  IPublisherMeta,
+} from "../interfaces/publisher-config.interface";
 import { Respondable } from "../interfaces/respondable.interface";
 import { EventProcessor } from "../mixins/event-processor.mixin";
-import { ESState, PublisherRole } from "../moirae.constants";
+import {
+  COMMAND_PUBLISHER,
+  ESState,
+  EVENT_PUBLISHER,
+  PublisherToken,
+  QUERY_PUBLISHER,
+} from "../moirae.constants";
 import { Distributor } from "./distributor.class";
 import { ResponseWrapper } from "./response.class";
 import { StateTracker } from "./state-tracker.class";
@@ -27,7 +36,7 @@ export abstract class BasePublisher<Evt extends Respondable>
   protected _status: StateTracker<ESState>;
   protected readonly _uuid: string;
 
-  public role: PublisherRole;
+  public role: PublisherToken;
 
   constructor(
     observableFactory: ObservableFactory,
@@ -50,6 +59,17 @@ export abstract class BasePublisher<Evt extends Respondable>
 
   protected get _key(): string {
     return `${this._uuid}:${EVENT_KEY}`;
+  }
+
+  protected getRoleConfig<T extends IPublisherConfig>(): T {
+    switch (this.role) {
+      case COMMAND_PUBLISHER:
+        return this.publisherOptions["command"];
+      case EVENT_PUBLISHER:
+        return this.publisherOptions["event"];
+      case QUERY_PUBLISHER:
+        return this.publisherOptions["query"];
+    }
   }
 
   public async acknowledgeEvent(event: Evt): Promise<void> {

--- a/packages/core/lib/exceptions/invalid-configuration.error.ts
+++ b/packages/core/lib/exceptions/invalid-configuration.error.ts
@@ -1,0 +1,6 @@
+export class InvalidConfigurationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/core/lib/interfaces/config.interface.ts
+++ b/packages/core/lib/interfaces/config.interface.ts
@@ -21,7 +21,9 @@ export interface IMoiraeConfig<
    */
   externalTypes?: ClassConstructor<unknown>[];
   /**
-   * Publisher provides messaging and communication for Commands, Events, and Queries
+   * Publisher provides messaging and communication for Commands, Events, and Queries. This
+   * can be specialized for each distribution type, having a different publisher configuration
+   * for each of Commands, Events, and Queries.
    */
   publisher?: IPublisherMeta & {
     command: TCommand;

--- a/packages/core/lib/interfaces/config.interface.ts
+++ b/packages/core/lib/interfaces/config.interface.ts
@@ -1,13 +1,15 @@
 import { ModuleMetadata, Provider } from "@nestjs/common";
 import { ClassConstructor } from "class-transformer";
 import { ICacheConfig } from "./cache-config.interface";
-import { IPublisherConfig } from "./publisher-config.interface";
+import { IPublisherConfig, IPublisherMeta } from "./publisher-config.interface";
 import { IStoreConfig } from "./store-config.interface";
 
 export interface IMoiraeConfig<
   TCache extends ICacheConfig,
-  TPub extends IPublisherConfig,
   TStore extends IStoreConfig,
+  TCommand extends IPublisherConfig,
+  TEvent extends IPublisherConfig,
+  TQuery extends IPublisherConfig,
 > extends Pick<ModuleMetadata, "imports"> {
   /**
    * Cache provides a storage mechanism internal to Moirae for rapid
@@ -19,9 +21,13 @@ export interface IMoiraeConfig<
    */
   externalTypes?: ClassConstructor<unknown>[];
   /**
-   * Publisher provides messaging and communication for Commands and Queries
+   * Publisher provides messaging and communication for Commands, Events, and Queries
    */
-  publisher?: TPub;
+  publisher?: IPublisherMeta & {
+    command: TCommand;
+    event: TEvent;
+    query: TQuery;
+  };
   sagas?: Provider[];
   /**
    * Store provides an event store to persist all events processed in the system.

--- a/packages/core/lib/interfaces/publisher-config.interface.ts
+++ b/packages/core/lib/interfaces/publisher-config.interface.ts
@@ -1,6 +1,10 @@
 export type PublisherType = "memory" | "rabbitmq";
 
 export interface IPublisherConfig {
+  type: PublisherType;
+}
+
+export interface IPublisherMeta {
   /**
    * In the case of a microservice system, define the domain token for this
    * specific microservice.
@@ -12,5 +16,4 @@ export interface IPublisherConfig {
    * Globally unique ID for the system. Suggested: kubernetes pod name
    */
   nodeId: string;
-  type: PublisherType;
 }

--- a/packages/core/lib/interfaces/publisher.interface.ts
+++ b/packages/core/lib/interfaces/publisher.interface.ts
@@ -1,5 +1,5 @@
 import { ResponseWrapper } from "../classes/response.class";
-import { PublisherRole } from "../moirae.constants";
+import { PublisherToken } from "../moirae.constants";
 import { IEventLike } from "./event-like.interface";
 
 /**
@@ -25,7 +25,7 @@ export interface IPublisher<Evt = IEventLike> {
   /**
    * Define the role of the publisher within the application. Set via the using class
    */
-  role: PublisherRole;
+  role: PublisherToken;
   /**
    * Subscribe to the bus. Should only be called ONCE by the relevant
    * bus as will trigger acknowledgements.

--- a/packages/core/lib/moirae.constants.ts
+++ b/packages/core/lib/moirae.constants.ts
@@ -2,18 +2,25 @@ export const APPLY_METADATA = "__apply_event_metadata__";
 export const CACHE_OPTIONS = "__cache-options__";
 export const CACHE_PROVIDER = "__cache-provider__";
 export const COMMAND_METADATA = "__command_handler__";
+export const COMMAND_PUBLISHER = "__command_publisher__";
 export const CORRELATION_PREFIX = "moirae__correlation";
 export const EVENT_METADATA = "__event_handler__";
 export const EVENT_PUBSUB_ENGINE = "__event-pubsub-engine__";
+export const EVENT_PUBLISHER = "__event_publisher__";
 export const EVENT_SOURCE = "__event_source__";
 export const EXCEPTION_METADATA = "__command_filter__";
 export const MANAGER = "__manager__";
 export const PROJECTION_METADATA = "__aggregate_projection__";
-export const PUBLISHER = "__publisher__";
 export const PUBLISHER_OPTIONS = "__publisher-options__";
 export const QUERY_METADATA = "__query_handler__";
+export const QUERY_PUBLISHER = "__query_publisher__";
 export const ROLLBACK_METADATA = "__rollback-event-metadata__";
 export const SAGA_METADATA = "__saga_handler__";
+
+export type PublisherToken =
+  | typeof COMMAND_PUBLISHER
+  | typeof EVENT_PUBLISHER
+  | typeof QUERY_PUBLISHER;
 
 /**
  * @internal

--- a/packages/core/lib/publishers/memory.publisher.ts
+++ b/packages/core/lib/publishers/memory.publisher.ts
@@ -3,7 +3,7 @@ import { BasePublisher } from "../classes/base.publisher";
 import { Queue } from "../classes/queue.class";
 import { ObservableFactory } from "../factories/observable.factory";
 import { IEventLike } from "../interfaces/event-like.interface";
-import { IPublisherConfig } from "../interfaces/publisher-config.interface";
+import { IPublisherMeta } from "../interfaces/publisher-config.interface";
 import { IPublisher } from "../interfaces/publisher.interface";
 import { ESState, PUBLISHER_OPTIONS } from "../moirae.constants";
 
@@ -16,7 +16,7 @@ export class MemoryPublisher<Evt extends IEventLike>
 
   constructor(
     observableFactory: ObservableFactory,
-    @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherConfig,
+    @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherMeta,
   ) {
     super(observableFactory, publisherOptions);
   }

--- a/packages/core/lib/stores/memory.store.ts
+++ b/packages/core/lib/stores/memory.store.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from "@nestjs/common";
 import { ObservableFactory } from "../factories/observable.factory";
 import { IEventSource } from "../interfaces/event-source.interface";
 import { IEvent } from "../interfaces/event.interface";
-import { IPublisherConfig } from "../interfaces/publisher-config.interface";
+import { IPublisherMeta } from "../interfaces/publisher-config.interface";
 import { PublisherRole, PUBLISHER_OPTIONS } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
 
@@ -15,7 +15,7 @@ export class MemoryStore
 
   constructor(
     observableFactory: ObservableFactory,
-    @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherConfig,
+    @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherMeta,
   ) {
     super(observableFactory, publisherOptions);
     this.role = PublisherRole.EVENT_STORE;

--- a/packages/core/lib/stores/memory.store.ts
+++ b/packages/core/lib/stores/memory.store.ts
@@ -3,7 +3,7 @@ import { ObservableFactory } from "../factories/observable.factory";
 import { IEventSource } from "../interfaces/event-source.interface";
 import { IEvent } from "../interfaces/event.interface";
 import { IPublisherMeta } from "../interfaces/publisher-config.interface";
-import { PublisherRole, PUBLISHER_OPTIONS } from "../moirae.constants";
+import { EVENT_PUBLISHER, PUBLISHER_OPTIONS } from "../moirae.constants";
 import { MemoryPublisher } from "../publishers/memory.publisher";
 
 @Injectable()
@@ -18,7 +18,7 @@ export class MemoryStore
     @Inject(PUBLISHER_OPTIONS) publisherOptions: IPublisherMeta,
   ) {
     super(observableFactory, publisherOptions);
-    this.role = PublisherRole.EVENT_STORE;
+    this.role = EVENT_PUBLISHER;
   }
 
   public async appendToStream(eventList: IEvent[]): Promise<IEvent[]> {

--- a/packages/node-plugin/README.md
+++ b/packages/node-plugin/README.md
@@ -24,8 +24,12 @@ const rabbitMQConfig = {/* config contents */};
 const connection = new RabbitMQConnection(rabbitMQConfig);
 
 const moirae = new MoiraePlugin({
-    getPublisher: () =>
-        // Provide a way to instantiate new Publisher instances
+    // Provide a way to instantiate new Publisher instances
+    getCommandPublisher: () =>
+        new RabbitMQPublisher(new ObservableFactory(), rabbitMQConfig, rmqConnection),
+    getEventPublisher: () =>
+        new RabbitMQPublisher(new ObservableFactory(), rabbitMQConfig, rmqConnection),  
+    getQueryPublisher: () =>
         new RabbitMQPublisher(new ObservableFactory(), rabbitMQConfig, rmqConnection)
 });
 

--- a/packages/node-plugin/lib/busses/command.bus.ts
+++ b/packages/node-plugin/lib/busses/command.bus.ts
@@ -1,5 +1,6 @@
 import {
   CommandBus as MoiraeCommandBus,
+  COMMAND_PUBLISHER,
   ESState,
   Explorer,
   ICommand,
@@ -26,6 +27,7 @@ export class CommandBus extends MoiraeCommandBus {
       new SagaManagerMock() as unknown as SagaManager,
     );
     this.container = container;
+    this._publisher.role = COMMAND_PUBLISHER;
   }
 
   onApplicationBootstrap() {

--- a/packages/node-plugin/lib/busses/query.bus.ts
+++ b/packages/node-plugin/lib/busses/query.bus.ts
@@ -6,6 +6,7 @@ import {
   IQuery,
   ObservableFactory,
   QueryBus as MoiraeQueryBus,
+  QUERY_PUBLISHER,
 } from "@moirae/core";
 import { Container } from "../classes/container.class";
 import { RegisterQueryHandlerInput } from "../interfaces/register-container-input.interface";
@@ -19,6 +20,7 @@ export class QueryBus extends MoiraeQueryBus {
   ) {
     super(container as unknown as Explorer, observableFactory, publisher);
     this.container = container;
+    this._publisher.role = QUERY_PUBLISHER;
   }
 
   onApplicationBootstrap() {

--- a/packages/node-plugin/lib/classes/moirae-plugin.class.ts
+++ b/packages/node-plugin/lib/classes/moirae-plugin.class.ts
@@ -25,10 +25,10 @@ export class MoiraePlugin {
   private readonly _observableFactory: ObservableFactory;
 
   constructor(config: MoiraePluginConfig) {
-    this._commandPublisher = config.getPublisher();
+    this._commandPublisher = config.getCommandPublisher();
     this._container = new Container();
     this._observableFactory = new ObservableFactory();
-    this._queryPublisher = config.getPublisher();
+    this._queryPublisher = config.getQueryPublisher();
 
     this._commandBus = new CommandBus(
       this._container,

--- a/packages/node-plugin/lib/interfaces/moirae-plugin-config.interface.ts
+++ b/packages/node-plugin/lib/interfaces/moirae-plugin-config.interface.ts
@@ -1,5 +1,7 @@
 import { IPublisher } from "@moirae/core";
 
 export interface MoiraePluginConfig {
-  getPublisher: () => IPublisher;
+  getCommandPublisher: () => IPublisher;
+  getEventPublisher: () => IPublisher;
+  getQueryPublisher: () => IPublisher;
 }

--- a/packages/rabbitmq/index.ts
+++ b/packages/rabbitmq/index.ts
@@ -1,5 +1,5 @@
 // interfaces
-export type { IRabbitMQConfig } from "./lib/interfaces/rabbitmq.config";
+export type { IRabbitMQPublisherConfig } from "./lib/interfaces/rabbitmq-publisher.config";
 export { RabbitPubSubEngine } from "./lib/providers/rabbit-pubsub.engine";
 // providers
 export { RabbitMQConnection } from "./lib/providers/rabbitmq.connection";

--- a/packages/rabbitmq/lib/interfaces/rabbitmq-publisher.config.ts
+++ b/packages/rabbitmq/lib/interfaces/rabbitmq-publisher.config.ts
@@ -1,0 +1,8 @@
+import { IPublisherMeta } from "@moirae/core";
+import { IRabbitMQConfig } from "./rabbitmq.config";
+
+export interface IRabbitMQPublisherConfig extends IPublisherMeta {
+  command: IRabbitMQConfig;
+  event: IRabbitMQConfig;
+  query: IRabbitMQConfig;
+}

--- a/packages/rabbitmq/lib/providers/rabbit-pubsub.engine.spec.ts
+++ b/packages/rabbitmq/lib/providers/rabbit-pubsub.engine.spec.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { ObservableFactory, PUBLISHER_OPTIONS } from "@moirae/core";
+import {
+  IPublisherMeta,
+  ObservableFactory,
+  PUBLISHER_OPTIONS,
+} from "@moirae/core";
 import { Test } from "@nestjs/testing";
 import { Channel } from "amqplib";
 import { IRabbitMQConfig } from "../interfaces/rabbitmq.config";
@@ -13,11 +17,9 @@ describe("RabbitPubSubEngine", () => {
   let connection: RabbitMQConnection;
   let engine: RabbitPubSubEngine;
 
-  const options: IRabbitMQConfig = {
-    amqplib: {},
-    namespaceRoot: "__testing__",
+  const options: IPublisherMeta & { event: IRabbitMQConfig } = {
+    event: { amqplib: {}, namespaceRoot: "__testing__", type: "rabbitmq" },
     nodeId: "__testing__",
-    type: "rabbitmq",
   };
 
   beforeEach(async () => {

--- a/packages/rabbitmq/lib/providers/rabbit-pubsub.engine.ts
+++ b/packages/rabbitmq/lib/providers/rabbit-pubsub.engine.ts
@@ -14,7 +14,7 @@ import {
 } from "@nestjs/common";
 import { Channel, ConsumeMessage } from "amqplib";
 import { randomUUID } from "crypto";
-import { IRabbitMQConfig } from "../interfaces/rabbitmq.config";
+import { IRabbitMQPublisherConfig } from "../interfaces/rabbitmq-publisher.config";
 import { RabbitMQConnection } from "./rabbitmq.connection";
 
 @Injectable()
@@ -31,12 +31,12 @@ export class RabbitPubSubEngine
   constructor(
     private readonly _connection: RabbitMQConnection,
     observableFactory: ObservableFactory,
-    @Inject(PUBLISHER_OPTIONS) publisherOptions: IRabbitMQConfig,
+    @Inject(PUBLISHER_OPTIONS) publisherOptions: IRabbitMQPublisherConfig,
   ) {
     super();
     this._distributor = observableFactory.generateDistributor(randomUUID());
-    this._PUB_EXCHANGE = `${publisherOptions.namespaceRoot}-pubsub`;
-    this._SUB_QUEUE = `${publisherOptions.namespaceRoot}-subqueue-${publisherOptions.nodeId}`;
+    this._PUB_EXCHANGE = `${publisherOptions.event.namespaceRoot}-pubsub`;
+    this._SUB_QUEUE = `${publisherOptions.event.namespaceRoot}-subqueue-${publisherOptions.nodeId}`;
   }
 
   public async beforeApplicationShutdown() {

--- a/packages/rabbitmq/lib/publishers/rabbitmq.publiser.spec.ts
+++ b/packages/rabbitmq/lib/publishers/rabbitmq.publiser.spec.ts
@@ -5,12 +5,13 @@ import {
   Event,
   IEvent,
   ObservableFactory,
-  PublisherRole,
   PUBLISHER_OPTIONS,
+  QUERY_PUBLISHER,
 } from "@moirae/core";
 import { Test } from "@nestjs/testing";
 import { Channel, Message } from "amqplib";
 import { EventEmitter } from "events";
+import { IRabbitMQPublisherConfig } from "../interfaces/rabbitmq-publisher.config";
 import { IRabbitMQConfig } from "../interfaces/rabbitmq.config";
 import { RabbitMQConnection } from "../providers/rabbitmq.connection";
 import { createMockChannel } from "../testing/channel.mock";
@@ -27,11 +28,16 @@ describe("RabbitMQPublisher", () => {
   let publisher: RabbitMQPublisher;
   let connection: RabbitMQConnection;
 
-  const options: IRabbitMQConfig = {
-    amqplib: {},
-    namespaceRoot: "__testing__",
+  const options: IRabbitMQPublisherConfig = {
+    command: {} as IRabbitMQConfig,
+    event: {} as IRabbitMQConfig,
+    query: {
+      amqplib: {},
+      namespaceRoot: "__testing__",
+      type: "rabbitmq",
+    },
+    domain: "default",
     nodeId: "__testing__",
-    type: "rabbitmq",
   };
 
   beforeEach(async () => {
@@ -51,7 +57,7 @@ describe("RabbitMQPublisher", () => {
     }).compile();
 
     publisher = await module.resolve(RabbitMQPublisher);
-    publisher.role = PublisherRole.QUERY_BUS;
+    publisher.role = QUERY_PUBLISHER;
     connection = module.get(RabbitMQConnection);
   });
 

--- a/packages/typeorm/lib/stores/typeorm.store.spec.ts
+++ b/packages/typeorm/lib/stores/typeorm.store.spec.ts
@@ -1,10 +1,10 @@
 import {
   Event,
+  EVENT_PUBLISHER,
   IEvent,
   IPublisher,
   MemoryPublisher,
   ObservableFactory,
-  PUBLISHER,
   PUBLISHER_OPTIONS,
   RegisterType,
 } from "@moirae/core";
@@ -33,7 +33,7 @@ describe("TypeORMStore", () => {
         TypeORMStore,
         ObservableFactory,
         {
-          provide: PUBLISHER,
+          provide: EVENT_PUBLISHER,
           useClass: MemoryPublisher,
         },
         {

--- a/packages/typeorm/lib/stores/typeorm.store.ts
+++ b/packages/typeorm/lib/stores/typeorm.store.ts
@@ -4,7 +4,6 @@ import {
   IEvent,
   IEventSource,
   IPublisher,
-  PublisherRole,
 } from "@moirae/core";
 import { Inject, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -23,7 +22,7 @@ export class TypeORMStore
     private readonly repository: Repository<EventStore>,
   ) {
     super();
-    this.publisher.role = PublisherRole.EVENT_STORE;
+    this.publisher.role = EVENT_PUBLISHER;
   }
 
   public async appendToStream(

--- a/packages/typeorm/lib/stores/typeorm.store.ts
+++ b/packages/typeorm/lib/stores/typeorm.store.ts
@@ -1,9 +1,9 @@
 import {
   EventProcessor,
+  EVENT_PUBLISHER,
   IEvent,
   IEventSource,
   IPublisher,
-  PUBLISHER,
   PublisherRole,
 } from "@moirae/core";
 import { Inject, Injectable } from "@nestjs/common";
@@ -18,7 +18,7 @@ export class TypeORMStore
   implements IEventSource
 {
   constructor(
-    @Inject(PUBLISHER) private readonly publisher: IPublisher<IEvent>,
+    @Inject(EVENT_PUBLISHER) private readonly publisher: IPublisher<IEvent>,
     @InjectRepository(EventStore)
     private readonly repository: Repository<EventStore>,
   ) {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,10 @@
 {
-    "entryPoints": [".", "packages/**/package.json"],
+    "entryPoints": [".", "packages/*/package.json"],
     "entryPointStrategy": "Packages",
     "external-modulemap": ".*\/packages\/([^\/]+)\/.*",
     "includeVersion": true,
-    "name": "Moirae"
+    "name": "Moirae",
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
Add separation of publishers based on action types. For example:
- Commands are published via gRPC (to be built)
- Queries are published via HTTP (to be build)
- Events are published via RabbitMQ